### PR TITLE
Add LoRA fine-tuning example

### DIFF
--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -1,0 +1,113 @@
+"""Minimal LoRA fine-tuning utility for TranscriptFormer.
+
+Example
+-------
+>>> python finetune_lora.py \
+...     --checkpoint-path ./checkpoints/tf_sapiens \
+...     --train-files train.h5ad \
+...     --output-path lora_weights.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from types import SimpleNamespace
+
+import pytorch_lightning as pl
+import torch
+from torch.utils.data import DataLoader
+
+from transcriptformer.data.dataclasses import DataConfig, LossConfig, ModelConfig
+from transcriptformer.data.dataloader import AnnDataset
+from transcriptformer.model.lora import apply_lora, lora_state_dict
+from transcriptformer.model.model import Transcriptformer
+from transcriptformer.tokenizer.vocab import load_vocabs_and_embeddings
+
+
+def load_configs(checkpoint_path: str) -> tuple[DataConfig, ModelConfig, LossConfig]:
+    """Load dataclass configs from a checkpoint directory."""
+    with open(os.path.join(checkpoint_path, "config.json")) as f:
+        cfg = json.load(f)["model"]
+    return (
+        DataConfig(**cfg["data_config"]),
+        ModelConfig(**cfg["model_config"]),
+        LossConfig(**cfg["loss_config"]),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LoRA fine-tuning for TranscriptFormer")
+    parser.add_argument("--checkpoint-path", required=True, help="Directory with model checkpoint")
+    parser.add_argument("--train-files", nargs="+", required=True, help="Training h5ad files")
+    parser.add_argument("--output-path", default="lora_weights.pt", help="File to save LoRA weights")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--lora-r", type=int, default=4)
+    parser.add_argument("--lora-alpha", type=float, default=1.0)
+    args = parser.parse_args()
+
+    data_cfg, model_cfg, loss_cfg = load_configs(args.checkpoint_path)
+
+    # Update paths relative to checkpoint
+    if not os.path.isabs(data_cfg.aux_vocab_path):
+        data_cfg.aux_vocab_path = os.path.join(args.checkpoint_path, data_cfg.aux_vocab_path)
+    if data_cfg.esm2_mappings_path and not os.path.isabs(data_cfg.esm2_mappings_path):
+        data_cfg.esm2_mappings_path = os.path.join(args.checkpoint_path, data_cfg.esm2_mappings_path)
+
+    dummy_cfg = SimpleNamespace(model=SimpleNamespace(data_config=data_cfg))
+    (gene_vocab, aux_vocab), emb_matrix = load_vocabs_and_embeddings(dummy_cfg)
+
+    model = Transcriptformer(
+        data_config=data_cfg,
+        model_config=model_cfg,
+        loss_config=loss_cfg,
+        gene_vocab_dict=gene_vocab,
+        aux_vocab_dict=aux_vocab,
+        emb_matrix=emb_matrix,
+    )
+
+    weights_path = os.path.join(args.checkpoint_path, "model_weights.pt")
+    if os.path.exists(weights_path):
+        state = torch.load(weights_path, map_location="cpu", weights_only=True)
+        model.load_state_dict(state)
+
+    apply_lora(model, r=args.lora_r, alpha=args.lora_alpha)
+
+    dataset = AnnDataset(
+        files_list=args.train_files,
+        gene_vocab=gene_vocab,
+        aux_vocab=aux_vocab,
+        max_len=model_cfg.seq_len,
+        normalize_to_scale=data_cfg.normalize_to_scale,
+        sort_genes=data_cfg.sort_genes,
+        randomize_order=data_cfg.randomize_genes,
+        pad_zeros=data_cfg.pad_zeros,
+        gene_col_name=data_cfg.gene_col_name,
+        filter_to_vocab=data_cfg.filter_to_vocabs,
+        filter_outliers=data_cfg.filter_outliers,
+        min_expressed_genes=data_cfg.min_expressed_genes,
+        pad_token=data_cfg.gene_pad_token,
+        clip_counts=data_cfg.clip_counts,
+        obs_keys=None,
+        use_raw=data_cfg.use_raw,
+    )
+
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=data_cfg.n_data_workers,
+        collate_fn=dataset.collate_fn,
+        pin_memory=data_cfg.pin_memory,
+    )
+
+    trainer = pl.Trainer(max_epochs=args.epochs, devices=1, accelerator="auto")
+    trainer.fit(model, loader)
+
+    torch.save(lora_state_dict(model), args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/transcriptformer/model/lora.py
+++ b/src/transcriptformer/model/lora.py
@@ -1,0 +1,64 @@
+"""Lightweight LoRA utilities."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import torch
+from torch import nn
+
+
+class LoRALinear(nn.Module):
+    """A linear layer augmented with LoRA weights."""
+
+    def __init__(self, in_features: int, out_features: int, r: int = 4, alpha: float = 1.0, bias: bool = True) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+        for p in self.linear.parameters():
+            p.requires_grad = False
+
+        self.weight_a = nn.Parameter(torch.zeros(r, in_features))
+        self.weight_b = nn.Parameter(torch.zeros(out_features, r))
+        nn.init.kaiming_uniform_(self.weight_a, a=math.sqrt(5))
+        nn.init.zeros_(self.weight_b)
+        self.scaling = alpha / r
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute the linear transformation with LoRA adaptation."""
+        result = self.linear(x)
+        lora_out = nn.functional.linear(x, self.weight_b @ self.weight_a) * self.scaling
+        return result + lora_out
+
+
+def _replace_module(parent: nn.Module, child_name: str, new_module: nn.Module) -> None:
+    setattr(parent, child_name, new_module)
+
+
+def apply_lora(module: nn.Module, r: int = 4, alpha: float = 1.0) -> None:
+    """Recursively replace ``nn.Linear`` modules with :class:`LoRALinear`."""
+    for name, child in list(module.named_children()):
+        if isinstance(child, nn.Linear):
+            lora_layer = LoRALinear(child.in_features, child.out_features, r=r, alpha=alpha, bias=child.bias is not None)
+            lora_layer.linear.weight.data.copy_(child.weight.data)
+            if child.bias is not None:
+                lora_layer.linear.bias.data.copy_(child.bias.data)
+            _replace_module(module, name, lora_layer)
+        else:
+            apply_lora(child, r=r, alpha=alpha)
+
+
+def iter_lora_layers(module: nn.Module) -> Iterator[tuple[str, LoRALinear]]:
+    """Yield names and layers for all :class:`LoRALinear` modules."""
+    for name, child in module.named_modules():
+        if isinstance(child, LoRALinear):
+            yield name, child
+
+
+def lora_state_dict(module: nn.Module) -> dict[str, torch.Tensor]:
+    """Return a state_dict containing only LoRA parameters."""
+    state = {}
+    for name, layer in iter_lora_layers(module):
+        state[f"{name}.weight_a"] = layer.weight_a.detach().cpu()
+        state[f"{name}.weight_b"] = layer.weight_b.detach().cpu()
+    return state


### PR DESCRIPTION
## Summary
- add minimal `LoRALinear` implementation and helpers
- provide `finetune_lora.py` script to train LoRA adapters

## Testing
- `ruff check finetune_lora.py src/transcriptformer/model/lora.py`
- `pip install pytest -q` *(fails: No route to host)*