### PR TITLE
Enhance LoRA utilities and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ Run the example with:
 python finetune_lora.py \
   --checkpoint-path ./checkpoints/tf_sapiens \
   --train-files path/to/train.h5ad \
+  --lora-r 4 \
+  --lora-alpha 16 \
+  --lora-dropout 0.0 \
+  --lora-target-modules linear1 linear2 linears
 ```
 
 The script uses `AnnDataset` for preprocessing so the inputs match those used during pretraining. Training logic is minimal (one epoch with PyTorch Lightning) and is intended as a starting point for custom fine‑tuning workflows. Only the adapter weights are saved to keep checkpoints small.

--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -52,6 +52,12 @@ def main() -> None:
     parser.add_argument("--lora-r", type=int, default=4)
     parser.add_argument("--lora-alpha", type=float, default=16.0)
     parser.add_argument("--lora-dropout", type=float, default=0.0)
+    parser.add_argument(
+        "--lora-target-modules",
+        nargs="+",
+        default=("linear1", "linear2", "linears"),
+        help="Qualified name substrings of Linear modules to LoRA-ize",
+    )
     args = parser.parse_args()
 
     data_cfg, model_cfg, loss_cfg = load_configs(args.checkpoint_path)
@@ -79,7 +85,12 @@ def main() -> None:
         state = torch.load(weights_path, map_location="cpu", weights_only=True)
         model.load_state_dict(state)
 
-    lora_cfg = LoRAConfig(r=args.lora_r, alpha=args.lora_alpha, dropout=args.lora_dropout)
+    lora_cfg = LoRAConfig(
+        r=args.lora_r,
+        alpha=args.lora_alpha,
+        dropout=args.lora_dropout,
+        target_modules=tuple(args.lora_target_modules),
+    )
     apply_lora(model, lora_cfg)
 
     dataset = AnnDataset(

--- a/src/transcriptformer/model/__init__.py
+++ b/src/transcriptformer/model/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .lora import LoRALinear, LoRAConfig, apply_lora, iter_lora_layers, lora_state_dict
+from .lora import LoRAConfig, LoRALinear, apply_lora, iter_lora_layers, lora_state_dict
 
 __all__ = [
     "LoRALinear",
@@ -11,4 +11,3 @@ __all__ = [
     "iter_lora_layers",
     "lora_state_dict",
 ]
-


### PR DESCRIPTION
## Summary
- implement LoRA output dropout and prefix-aware layer replacement
- expose LoRA utilities via the model package
- add target module argument to `finetune_lora.py`
- document LoRA CLI options in the README

## Testing
- `ruff check finetune_lora.py src/transcriptformer/model/lora.py src/transcriptformer/model/__init__.py`
- `python -m pytest -q` *(fails: No module named pytest)*