### PR TITLE
Expose Transcriptformer from model package

### DIFF
--- a/src/transcriptformer/model/__init__.py
+++ b/src/transcriptformer/model/__init__.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from .lora import LoRAConfig, LoRALinear, apply_lora, iter_lora_layers, lora_state_dict
+from .model import Transcriptformer
 
 __all__ = [
+    "Transcriptformer",
     "LoRALinear",
     "LoRAConfig",
     "apply_lora",


### PR DESCRIPTION
## Summary
- re-export the main model and LoRA helpers

## Testing
- `ruff check src/transcriptformer/model/__init__.py`
